### PR TITLE
feat(nouns-camp): add applications feature

### DIFF
--- a/apps/nouns-camp/next.config.mjs
+++ b/apps/nouns-camp/next.config.mjs
@@ -107,6 +107,7 @@ export default withSentry(
     rewrites() {
       return [
         { source: "/topics/:path*", destination: "/candidates/:path*" },
+        { source: "/applications/:path*", destination: "/candidates/:path*" },
         { source: "/sw.js", destination: "/service-worker.js" },
         {
           source: "/subgraphs/nouns",

--- a/apps/nouns-camp/src/app/applications/page.js
+++ b/apps/nouns-camp/src/app/applications/page.js
@@ -1,0 +1,8 @@
+"use client";
+
+import React from "react";
+import BrowseCandidatesScreen from "@/components/browse-candidates-screen";
+
+export default function Applications() {
+  return <BrowseCandidatesScreen candidateType="application" />;
+}

--- a/apps/nouns-camp/src/components/sectioned-list.jsx
+++ b/apps/nouns-camp/src/components/sectioned-list.jsx
@@ -767,8 +767,9 @@ const CandidateOrTopicListItem = React.memo(
     const isCanceled = candidate.canceledTimestamp != null;
     const isPromoted = candidate.latestVersion.proposalId != null;
     const isProposalUpdate = candidate.latestVersion.targetProposalId != null;
-    const isProposalThresholdMet = candidateVotingPower > proposalThreshold;
     const isTopic = candidate?.latestVersion?.type === "topic";
+    const isApplication = candidate?.latestVersion?.type === "application";
+    const isProposalThresholdMet = candidateVotingPower > proposalThreshold;
 
     const hasUpdate =
       candidate.lastUpdatedTimestamp != null &&
@@ -831,14 +832,18 @@ const CandidateOrTopicListItem = React.memo(
           href={
             isTopic
               ? `/topics/${encodeURIComponent(makeCandidateUrlId(candidateId))}`
-              : `/candidates/${encodeURIComponent(makeCandidateUrlId(candidateId))}`
+              : isApplication
+                ? `/applications/${encodeURIComponent(makeCandidateUrlId(candidateId))}`
+                : `/candidates/${encodeURIComponent(makeCandidateUrlId(candidateId))}`
           }
           aria-label={[
             isProposalUpdate
               ? `Proposal ${candidate.targetProposalId} update`
               : isTopic
                 ? "Topic"
-                : `Candidate ${candidate.number}`,
+                : isApplication
+                  ? "Application"
+                  : `Candidate ${candidate.number}`,
             candidate.latestVersion.content.title,
           ].join(": ")}
         />
@@ -855,7 +860,9 @@ const CandidateOrTopicListItem = React.memo(
                   ? "Proposal update"
                   : isTopic
                     ? "Topic"
-                    : `Candidate ${candidate.number}`}{" "}
+                    : isApplication
+                      ? "Application"
+                      : `Candidate ${candidate.number}`}{" "}
                 by{" "}
                 <em
                   data-show={hasBeenOnScreen}

--- a/apps/nouns-camp/src/nouns-subgraph.js
+++ b/apps/nouns-camp/src/nouns-subgraph.js
@@ -3,7 +3,7 @@ import {
   object as objectUtils,
 } from "@shades/common/utils";
 import { parse as parseTransactions } from "@/utils/transactions";
-import { matchTopicTransactions } from "@/utils/candidates";
+import { matchTopicTransactions, isApplicationSlug } from "@/utils/candidates";
 
 const customSubgraphEndpoint =
   typeof location === "undefined"
@@ -377,7 +377,10 @@ export const parseCandidate = (data) => {
   if (data.versions != null)
     parsedData.versions = data.versions.map(parseCandidateVersion);
 
-  if (data.latestVersion?.content?.transactions != null) {
+  // Set the type based on slug pattern or transactions
+  if (data.slug != null && isApplicationSlug(data.slug)) {
+    parsedData.latestVersion.type = "application";
+  } else if (data.latestVersion?.content?.transactions != null) {
     parsedData.latestVersion.type = matchTopicTransactions(
       data.latestVersion.content.transactions,
     )

--- a/apps/nouns-camp/src/store.js
+++ b/apps/nouns-camp/src/store.js
@@ -2053,7 +2053,7 @@ export const useProposal = (id, { watch = true } = {}) => {
 };
 
 export const useProposalCandidates = ({
-  type, // proposal | topic
+  type, // proposal | topic | application
   includeCanceled = false,
   includePromoted = false,
   includeProposalUpdates = false,
@@ -2069,9 +2069,11 @@ export const useProposalCandidates = ({
     const filteredCandidates = candidates.filter((c) => {
       const isProposal = c?.latestVersion?.type === "proposal";
       const isTopic = c?.latestVersion?.type === "topic";
+      const isApplication = c?.latestVersion?.type === "application";
 
-      if (type === "topic" && isProposal) return false;
-      if (type === "proposal" && isTopic) return false;
+      if (type === "topic" && (isProposal || isApplication)) return false;
+      if (type === "proposal" && (isTopic || isApplication)) return false;
+      if (type === "application" && (isTopic || isProposal)) return false;
 
       if (c.canceledTimestamp != null)
         // Canceled candidates disregard other filters

--- a/apps/nouns-camp/src/utils/candidates.js
+++ b/apps/nouns-camp/src/utils/candidates.js
@@ -238,6 +238,10 @@ export const getScore = (candidate) => {
 
 const ZERO_ADDRESS = "0x".padEnd(42, "0");
 
+export const isApplicationSlug = (slug) => {
+  return slug.startsWith("nouns-grants-");
+};
+
 export const createTopicTransactions = () => [
   { type: "transfer", target: ZERO_ADDRESS, value: 0n },
 ];


### PR DESCRIPTION
## Summary
- Add applications feature as a new candidate type
- Create applications page and tab in landing UI
- Add routing for applications URLs
- Implement filtering and display logic for applications

## Test plan
- Navigate to '/applications' route to view applications list
- Check that applications appear properly in the landing page tabs
- Verify applications are correctly identified by their 'nouns-grants-' slug prefix