### PR TITLE
fix: display stream cancellation information

### DIFF
--- a/apps/nouns-camp/src/components/proposal-screen.jsx
+++ b/apps/nouns-camp/src/components/proposal-screen.jsx
@@ -1644,6 +1644,7 @@ const StreamStatus = ({ transaction }) => {
     elapsedTime,
     remainingBalance,
     recipientBalance,
+    recipientCancelBalance,
   } = useStreamData({ streamContractAddress });
   const { toggleStreamsDialog } = useScreenContext();
 
@@ -1732,7 +1733,7 @@ const StreamStatus = ({ transaction }) => {
     connectedWalletAccountAddress?.toLowerCase() ===
     receiverAddress?.toLowerCase();
 
-  const showWithdrawButton = isStreamRecipient && recipientBalance > 0;
+  const showWithdrawButton = isStreamRecipient && recipientBalance > 0 && recipientCancelBalance === 0;
 
   const streamStartsInFuture = Number(startTime) * 1000 > Date.now();
 
@@ -1754,7 +1755,24 @@ const StreamStatus = ({ transaction }) => {
         })
       }
     >
-      {streamStartsInFuture ? (
+      {recipientCancelBalance > 0 ? (
+        <>
+          Stream cancelled{" "}
+          {vestedAmount != null && vestedAmount > 0 && (
+            <span>
+              (
+              <a
+                href={buildEtherscanLink(`/address/${streamContractAddress}`)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {formattedVestedAmount}
+              </a>{" "}
+              vested)
+            </span>
+          )}
+        </>
+      ) : streamStartsInFuture ? (
         <>
           Stream starts vesting on{" "}
           <FormattedDateWithTooltip

--- a/apps/nouns-camp/src/components/proposal-screen.jsx
+++ b/apps/nouns-camp/src/components/proposal-screen.jsx
@@ -1733,7 +1733,8 @@ const StreamStatus = ({ transaction }) => {
     connectedWalletAccountAddress?.toLowerCase() ===
     receiverAddress?.toLowerCase();
 
-  const showWithdrawButton = isStreamRecipient && recipientBalance > 0 && recipientCancelBalance === 0;
+  const showWithdrawButton =
+    isStreamRecipient && recipientBalance > 0 && recipientCancelBalance === 0;
 
   const streamStartsInFuture = Number(startTime) * 1000 > Date.now();
 


### PR DESCRIPTION
This PR adds support for showing when streams have been cancelled in the proposal stream info box. The StreamStatus component now checks the recipientCancelBalance value and shows a cancellation message when appropriate.

Closes #115

Generated with [Claude Code](https://claude.ai/code)